### PR TITLE
Remove not-very-useful shorturl links

### DIFF
--- a/spec-update-draft.md
+++ b/spec-update-draft.md
@@ -684,7 +684,6 @@ Assess the losses directly linked to the slashing event. This can include:
 * Slashing leads to validator downtime until the slashed validator is exited
 * Missed rewards
 * Possible recoveries from insurance payments
-* The following resource can help to determine the losses for slashing and downtime: [https://shorturl.at/vxGM4](https://shorturl.at/vxGM4)
 
 **Direct Monetary Losses from a Downtime Event**\
 Assess the losses directly from the downtime event. This can include:
@@ -692,7 +691,6 @@ Assess the losses directly from the downtime event. This can include:
 * Downtime penalties until the validator is exited
 * Missed rewards
 * Possible recoveries from insurance payments
-* The following resource can help to determine the losses for slashing and downtime: [https://shorturl.at/vxGM4](https://shorturl.at/vxGM4)
 
 **Reputational Risks**\
 Determine the monetary loss from reputational damage. This includes:


### PR DESCRIPTION
It claims to help calculating losses, but points to a read-only spreadsheet describing the probability of getting a validator reward in a given number of days, given fixed values for relevant parameters that aren't fixed in reality.

Using a shortURL is a bad practice for transparency.